### PR TITLE
feat: Add params for function call key

### DIFF
--- a/near-connect/src/InjectedWallet.ts
+++ b/near-connect/src/InjectedWallet.ts
@@ -17,9 +17,11 @@ export class InjectedWallet {
     return this.wallet.manifest;
   }
 
-  async signIn(data?: { network?: Network }): Promise<Array<Account>> {
+  async signIn(data?: { network?: Network, contractId?: string, methodNames?: string[] }): Promise<Array<Account>> {
     const network = data?.network || this.connector.network;
-    return this.wallet.signIn({ network });
+    const contractId = data?.contractId || "";
+    const methodNames = data?.methodNames || [];
+    return this.wallet.signIn({ network, contractId, methodNames });
   }
 
   async signOut(data?: { network?: Network }): Promise<void> {

--- a/near-connect/src/NearConnector.ts
+++ b/near-connect/src/NearConnector.ts
@@ -246,8 +246,8 @@ export class NearConnector {
     });
   }
 
-  async connect(id?: string) {
-    await this.whenManifestLoaded.catch(() => {});
+  async connect({ id, contractId, methodNames }: { id?: string; contractId?: string; methodNames?: string[] } = {}) {
+    await this.whenManifestLoaded.catch(() => { });
     if (!id) id = await this.selectWallet();
 
     try {
@@ -257,7 +257,7 @@ export class NearConnector {
       await this.storage.set("selected-wallet", id);
       this.logger?.log(`Set preferred wallet, try to signIn`, id);
 
-      const accounts = await wallet.signIn();
+      const accounts = await wallet.signIn({ network: this.network, contractId, methodNames });
       if (!accounts?.length) throw new Error("Failed to sign in");
 
       await this.disconnectIfBanned(wallet, accounts);

--- a/near-connect/src/ParentFrameWallet.ts
+++ b/near-connect/src/ParentFrameWallet.ts
@@ -31,9 +31,11 @@ export class ParentFrameWallet {
     });
   }
 
-  async signIn(data?: { network?: Network }): Promise<Array<Account>> {
+  async signIn(data?: { network?: Network, contractId: string, methodNames: string[] }): Promise<Array<Account>> {
     const network = data?.network || this.connector.network;
-    const result = await this.callParentFrame("near:signIn", { network });
+    const contractId = data?.contractId || "";
+    const methodNames = data?.methodNames || [];
+    const result = await this.callParentFrame("near:signIn", { network, contractId, methodNames });
     if (Array.isArray(result)) return result;
     return [result as Account];
   }

--- a/near-connect/src/SandboxedWallet/index.ts
+++ b/near-connect/src/SandboxedWallet/index.ts
@@ -18,9 +18,11 @@ export class SandboxWallet {
     this.executor = new SandboxExecutor(connector, manifest);
   }
 
-  async signIn(data?: { network?: Network }): Promise<Array<Account>> {
+  async signIn(data?: { network?: Network, contractId?: string, methodNames?: string[] }): Promise<Array<Account>> {
     const network = data?.network || this.connector.network;
-    return this.executor.call("wallet:signIn", { network });
+    const contractId = data?.contractId || "";
+    const methodNames = data?.methodNames || [];
+    return this.executor.call("wallet:signIn", { network, contractId, methodNames });
   }
 
   async signOut(data?: { network?: Network }): Promise<void> {

--- a/near-connect/src/types/wallet.ts
+++ b/near-connect/src/types/wallet.ts
@@ -103,7 +103,7 @@ export interface NearWalletBase {
   /**
    * Programmatically sign in. Hardware wallets (e.g. Ledger) require `derivationPaths` to validate access key permissions.
    */
-  signIn(data?: { network?: Network }): Promise<Array<Account>>;
+  signIn(data?: { network?: Network, contractId?: string, methodNames?: string[] }): Promise<Array<Account>>;
   /**
    * Sign out from the wallet.
    */


### PR DESCRIPTION
In NEAR many wallets support creating a function call key while signing in. This PR adds the necessary parameters for those wallets to be able to create such key.

Just by adding the params, `meteor wallet` is able to create the key and use it to sign transactions on the app. 

However, I did not manage to make `intear` wallet work, do not know if it is because the params are lost within the `intear` iframe or somwhere else within this package.