### PR TITLE
feat: add plugins pattern

### DIFF
--- a/near-connect/src/helpers/plugin-manager.ts
+++ b/near-connect/src/helpers/plugin-manager.ts
@@ -1,0 +1,57 @@
+import type { NearWalletBase } from "../types/wallet";
+import type { Plugin, PluginResult } from "../types/plugin";
+
+export class PluginManager {
+  private plugins: Plugin[] = [];
+
+  use(plugin: Plugin): void {
+    this.plugins.push(plugin);
+  }
+
+  async executePluginChain<TArgs, TReturn>(
+    methodName: keyof Plugin,
+    wallet: NearWalletBase,
+    args: TArgs,
+    walletMethod: (args: TArgs) => Promise<TReturn>
+  ): Promise<TReturn> {
+    const executeChain = async (index: number, currentArgs: TArgs): Promise<TReturn> => {
+      if (index >= this.plugins.length) {
+        return walletMethod(currentArgs);
+      }
+
+      const plugin = this.plugins[index];
+      const pluginHandler = plugin[methodName] as any;
+
+      if (!pluginHandler) {
+        return executeChain(index + 1, currentArgs);
+      }
+
+      const result = (value: TReturn): PluginResult<TReturn> => ({
+        type: "result",
+        value,
+      });
+
+      const next = async (newArgs: TArgs): Promise<TReturn> => {
+        return executeChain(index + 1, newArgs);
+      };
+
+      const pluginResult = await pluginHandler.call(plugin, wallet, currentArgs, result, next);
+
+      if (pluginResult.type === "result") {
+        return pluginResult.value as TReturn;
+      } else {
+        return executeChain(index + 1, pluginResult.value);
+      }
+    };
+
+    return executeChain(0, args);
+  }
+
+  getPlugins(): Plugin[] {
+    return [...this.plugins];
+  }
+
+  clear(): void {
+    this.plugins = [];
+  }
+}

--- a/near-connect/src/helpers/wallet-proxy.ts
+++ b/near-connect/src/helpers/wallet-proxy.ts
@@ -1,0 +1,67 @@
+import type { NearWalletBase, SignAndSendTransactionParams, SignAndSendTransactionsParams, SignMessageParams, Account, SignedMessage, FinalExecutionOutcome, Network } from "../types/wallet";
+import { PluginManager } from "./plugin-manager";
+
+export class WalletProxy implements NearWalletBase {
+  constructor(
+    private wallet: NearWalletBase,
+    private pluginManager: PluginManager
+  ) {}
+
+  get manifest() {
+    return this.wallet.manifest;
+  }
+
+  async signIn(data?: { network?: Network; contractId?: string; methodNames?: string[] }): Promise<Account[]> {
+    return this.pluginManager.executePluginChain(
+      "signIn",
+      this.wallet,
+      data,
+      (args) => this.wallet.signIn(args)
+    );
+  }
+
+  async signOut(data?: { network?: Network }): Promise<void> {
+    return this.pluginManager.executePluginChain(
+      "signOut",
+      this.wallet,
+      data,
+      (args) => this.wallet.signOut(args)
+    );
+  }
+
+  async getAccounts(data?: { network?: Network }): Promise<Account[]> {
+    return this.pluginManager.executePluginChain(
+      "getAccounts",
+      this.wallet,
+      data,
+      (args) => this.wallet.getAccounts(args)
+    );
+  }
+
+  async signAndSendTransaction(params: SignAndSendTransactionParams): Promise<FinalExecutionOutcome> {
+    return this.pluginManager.executePluginChain(
+      "signAndSendTransaction",
+      this.wallet,
+      params,
+      (args) => this.wallet.signAndSendTransaction(args)
+    );
+  }
+
+  async signAndSendTransactions(params: SignAndSendTransactionsParams): Promise<FinalExecutionOutcome[]> {
+    return this.pluginManager.executePluginChain(
+      "signAndSendTransactions",
+      this.wallet,
+      params,
+      (args) => this.wallet.signAndSendTransactions(args)
+    );
+  }
+
+  async signMessage(params: SignMessageParams): Promise<SignedMessage> {
+    return this.pluginManager.executePluginChain(
+      "signMessage",
+      this.wallet,
+      params,
+      (args) => this.wallet.signMessage(args)
+    );
+  }
+}

--- a/near-connect/src/types/plugin.ts
+++ b/near-connect/src/types/plugin.ts
@@ -1,0 +1,80 @@
+import type { NearWalletBase, SignInParams, SignAndSendTransactionParams, SignAndSendTransactionsParams, SignMessageParams, Account, SignedMessage, FinalExecutionOutcome, Network } from "./wallet";
+
+export type PluginResult<T = any> =
+  | { type: "next"; value: any }
+  | { type: "result"; value: T };
+
+export type PluginResultFn<T> = (value: T) => PluginResult<T>;
+export type PluginNextFn<TArgs, TReturn> = (args: TArgs) => Promise<TReturn>;
+
+export interface PluginContext {
+  connector: any;
+}
+
+export interface Plugin {
+  /**
+   * Intercept signIn method
+   */
+  signIn?: (
+    wallet: NearWalletBase,
+    args: SignInParams | undefined,
+    result: PluginResultFn<Account[]>,
+    next: PluginNextFn<SignInParams | undefined, Account[]>
+  ) => Promise<PluginResult<Account[]>>;
+
+  /**
+   * Intercept signOut method
+   */
+  signOut?: (
+    wallet: NearWalletBase,
+    args: { network?: Network } | undefined,
+    result: PluginResultFn<void>,
+    next: PluginNextFn<{ network?: Network } | undefined, void>
+  ) => Promise<PluginResult<void>>;
+
+  /**
+   * Intercept getAccounts method
+   */
+  getAccounts?: (
+    wallet: NearWalletBase,
+    args: { network?: Network } | undefined,
+    result: PluginResultFn<Account[]>,
+    next: PluginNextFn<{ network?: Network } | undefined, Account[]>
+  ) => Promise<PluginResult<Account[]>>;
+
+  /**
+   * Intercept signAndSendTransaction method
+   */
+  signAndSendTransaction?: (
+    wallet: NearWalletBase,
+    tx: SignAndSendTransactionParams,
+    result: PluginResultFn<FinalExecutionOutcome>,
+    next: PluginNextFn<SignAndSendTransactionParams, FinalExecutionOutcome>
+  ) => Promise<PluginResult<FinalExecutionOutcome>>;
+
+  /**
+   * Intercept signAndSendTransactions method
+   */
+  signAndSendTransactions?: (
+    wallet: NearWalletBase,
+    params: SignAndSendTransactionsParams,
+    result: PluginResultFn<FinalExecutionOutcome[]>,
+    next: PluginNextFn<SignAndSendTransactionsParams, FinalExecutionOutcome[]>
+  ) => Promise<PluginResult<FinalExecutionOutcome[]>>;
+
+  /**
+   * Intercept signMessage method
+   */
+  signMessage?: (
+    wallet: NearWalletBase,
+    params: SignMessageParams,
+    result: PluginResultFn<SignedMessage>,
+    next: PluginNextFn<SignMessageParams, SignedMessage>
+  ) => Promise<PluginResult<SignedMessage>>;
+}
+
+/**
+ * Helper functions to create PluginResult objects
+ */
+export const createResult = <T>(value: T): PluginResult<T> => ({ type: "result", value });
+export const createNext = <T>(value: T): PluginResult<T> => ({ type: "next", value });


### PR DESCRIPTION
The wallet proxy wraps the real wallet. The plugin can use next to modify the parameters, or finish to return a value. It works like middleware.

Plugins such as the following can be generated

```ts
import { type Plugin } from "@hot-labs/near-connect";

const LoggingPlugin: Plugin = {
  async signIn(wallet, args, result, next) {
    console.log("[LoggingPlugin] 🔐 Sign In", { wallet: wallet.manifest.name });
    const startTime = Date.now();
    const accounts = await next(args);
    console.log("[LoggingPlugin] ✅ Sign In completed in", Date.now() - startTime, "ms");
    return result(accounts);
  },

  async signOut(wallet, args, result, next) {
    console.log("[LoggingPlugin] 🚪 Sign Out", { wallet: wallet.manifest.name });
    await next(args);
    console.log("[LoggingPlugin] ✅ Sign Out completed");
    return result(undefined);
  },

  async signAndSendTransaction(wallet, tx, result, next) {
    console.log("[LoggingPlugin] 📤 Transaction", {
      receiverId: tx.receiverId,
      actionsCount: tx.actions?.length
    });
    const startTime = Date.now();
    const outcome = await next(tx);
    console.log("[LoggingPlugin] ✅ Transaction completed in", Date.now() - startTime, "ms");
    return result(outcome);
  },

  async signAndSendTransactions(wallet, params, result, next) {
    console.log("[LoggingPlugin] 📤 Transactions", {
      count: params.transactions?.length
    });
    const startTime = Date.now();
    const outcomes = await next(params);
    console.log("[LoggingPlugin] ✅ Transactions completed in", Date.now() - startTime, "ms");
    return result(outcomes);
  },

  async signMessage(wallet, params, result, next) {
    console.log("[LoggingPlugin] ✍️ Sign Message", {
      message: params.message,
      recipient: params.recipient
    });
    const startTime = Date.now();
    const signed = await next(params);
    console.log("[LoggingPlugin] ✅ Message signed in", Date.now() - startTime, "ms");
    return result(signed);
  }
};
```
```ts
const connector = new NearConnector({
    network: "testnet",
})
    
connector.use(LoggingPlugin());
 ```