### PR TITLE
fix: scope heading styles

### DIFF
--- a/cdn/hot-connect.cjs.js
+++ b/cdn/hot-connect.cjs.js
@@ -11,7 +11,13 @@ ${r} *::-webkit-scrollbar {
   display: none;
 }
 
-${r} p, h1, h2, h3, h4, h5, h6 {
+${r} p,
+${r} h1,
+${r} h2,
+${r} h3,
+${r} h4,
+${r} h5,
+${r} h6 {
   margin: 0;
 }
 

--- a/cdn/hot-connect.es.js
+++ b/cdn/hot-connect.es.js
@@ -252,7 +252,13 @@ ${r} *::-webkit-scrollbar {
   display: none;
 }
 
-${r} p, h1, h2, h3, h4, h5, h6 {
+${r} p,
+${r} h1,
+${r} h2,
+${r} h3,
+${r} h4,
+${r} h5,
+${r} h6 {
   margin: 0;
 }
 

--- a/cdn/hot-connect.iife.js
+++ b/cdn/hot-connect.iife.js
@@ -11,7 +11,13 @@ ${r} *::-webkit-scrollbar {
   display: none;
 }
 
-${r} p, h1, h2, h3, h4, h5, h6 {
+${r} p,
+${r} h1,
+${r} h2,
+${r} h3,
+${r} h4,
+${r} h5,
+${r} h6 {
   margin: 0;
 }
 

--- a/src/popups/styles.ts
+++ b/src/popups/styles.ts
@@ -11,7 +11,13 @@ ${id} *::-webkit-scrollbar {
   display: none;
 }
 
-${id} p, h1, h2, h3, h4, h5, h6 {
+${id} p,
+${id} h1,
+${id} h2,
+${id} h3,
+${id} h4,
+${id} h5,
+${id} h6 {
   margin: 0;
 }
 


### PR DESCRIPTION
This was raised in https://github.com/azbang/near-connect/issues/16 and is still an issue. The `p` class is scoped but not the `h1`, `h2`, `h3`, `h4`, `h5`, `h6` classes. Meaning this ends up generating something like the screenshot below and globally overrides those header margins wherever the package is installed.

<img width="272" height="60" alt="image" src="https://github.com/user-attachments/assets/aa63a90e-6c13-43f4-ab58-c27b60579f07" />
