### PR TITLE
Enable `signDelegateActions` in NEARMobile manifest

### DIFF
--- a/repository/manifest.json
+++ b/repository/manifest.json
@@ -221,6 +221,9 @@
         "signInWithFunctionCallKey": true,
         "signAndSendTransaction": true,
         "signAndSendTransactions": true,
+        "signDelegateActions": true,
+        "verifyOwner": false,
+        "mainnet": true,
         "testnet": false
       },
 


### PR DESCRIPTION
**PR Description:**
Adds support for `signDelegateActions` in the NEARMobile manifest configuration. This enables delegate action signing while keeping existing permissions unchanged.
