### PR TITLE
feat: add cspNonce option for nonce-based CSP compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.4
+
+- Add `cspNonce` option to `NearConnector` for CSP compliance. When set, the nonce is added to both `<script>` tags inside the `srcdoc` sandbox iframe, allowing them to execute under nonce-based Content Security Policy.
+
 # 0.11.3
 
 - Export `EventMap`, `EventType`, and `Account` types from barrel

--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ const selector = new NearConnector({
 });
 ```
 
+## Content Security Policy (CSP)
+
+If your site uses nonce-based CSP (e.g. `script-src 'nonce-abc123'`), the sandboxed iframe's inline scripts will be blocked because `srcdoc` iframes inherit the parent's CSP. Pass your nonce to `NearConnector` to allow the scripts to execute:
+
+```ts
+const connector = new NearConnector({
+  cspNonce: document.querySelector('script[nonce]')?.getAttribute('nonce') ?? undefined,
+});
+```
+
+This adds the nonce to both `<script>` tags inside the iframe — the runtime bridge (`window.selector`) and the wallet module code. Without it, the iframe loads but neither script executes.
+
 ## How to add my wallet?
 
 When you develop a connector for your wallet, you can immediately test your code on real applications that use NEAR Connect. Super easy!

--- a/llms.txt
+++ b/llms.txt
@@ -68,6 +68,7 @@ interface NearConnectorOptions {
   walletConnect?: { projectId: string; metadata: any };
   isBannedNearAddress?: (address: string) => Promise<boolean>;
   signIn?: { contractId?: string; methodNames?: string[] };  // Deprecated
+  cspNonce?: string;                       // CSP nonce for srcdoc iframe scripts
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hot-labs/near-connect",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "commonjs",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/NearConnector.ts
+++ b/src/NearConnector.ts
@@ -22,7 +22,7 @@ import { ParentFrameWallet } from "./ParentFrameWallet";
 import { InjectedWallet } from "./InjectedWallet";
 import { SandboxWallet } from "./SandboxedWallet";
 
-interface NearConnectorOptions {
+export interface NearConnectorOptions {
   providers?: { mainnet?: string[]; testnet?: string[] };
   features?: Partial<WalletFeatures>;
   excludedWallets?: string[];
@@ -35,6 +35,7 @@ interface NearConnectorOptions {
   events?: EventEmitter<EventMap>;
   storage?: DataStorage;
   logger?: Logger;
+  cspNonce?: string;
 
   /**
    * Footer branding for the wallet selector popup. If not provided, default branding will be used. If provided null, footer will be hidden.
@@ -85,6 +86,7 @@ export class NearConnector {
   footerBranding: FooterBranding | null;
   excludedWallets: string[] = [];
   autoConnect?: boolean;
+  cspNonce?: string;
 
   readonly whenManifestLoaded: Promise<void>;
 
@@ -93,6 +95,7 @@ export class NearConnector {
     this.storage = options?.storage ?? new LocalStorage();
     this.events = options?.events ?? new EventEmitter<EventMap>();
     this.logger = options?.logger;
+    this.cspNonce = options?.cspNonce;
 
     this.network = options?.network ?? "mainnet";
     this.walletConnect = options?.walletConnect;

--- a/src/SandboxedWallet/code.ts
+++ b/src/SandboxedWallet/code.ts
@@ -1,7 +1,7 @@
 import { NEAR_CONNECT_VERSION } from "../nearConnectStatic";
 import SandboxExecutor from "./executor";
 
-async function getIframeCode(args: { id: string; executor: SandboxExecutor; code: string }) {
+async function getIframeCode(args: { id: string; executor: SandboxExecutor; code: string; cspNonce?: string }) {
   const storage = await args.executor.getAllStorage();
   const providers = args.executor.connector.providers;
   const manifest = args.executor.manifest;
@@ -11,6 +11,8 @@ async function getIframeCode(args: { id: string; executor: SandboxExecutor; code
     .replaceAll(".localStorage", ".sandboxedLocalStorage")
     .replaceAll("window.top", "window.selector")
     .replaceAll("window.open", "window.selector.open");
+
+  const nonceAttr = args.cspNonce ? ` nonce="${args.cspNonce.replace(/[^A-Za-z0-9+/=]/g, "")}"` : "";
 
   return /* html */ `
   <!DOCTYPE html>
@@ -101,7 +103,7 @@ async function getIframeCode(args: { id: string; executor: SandboxExecutor; code
       </style>
 
 
-      <script>
+      <script${nonceAttr}>
       window.sandboxedLocalStorage = (() => {
         let storage = ${JSON.stringify(storage)}
 
@@ -320,7 +322,7 @@ async function getIframeCode(args: { id: string; executor: SandboxExecutor; code
       });
       </script>
 
-      <script type="module">${code}</script>
+      <script type="module"${nonceAttr}>${code}</script>
     </body>
   </html>
     `;

--- a/src/SandboxedWallet/executor.ts
+++ b/src/SandboxedWallet/executor.ts
@@ -314,7 +314,7 @@ class SandboxExecutor {
     const code = await this.loadCode();
     this.connector.logger?.log(`Code loaded, preparing`);
 
-    const iframe = new IframeExecutor(this, code, this._onMessage);
+    const iframe = new IframeExecutor(this, code, this._onMessage, this.connector.cspNonce);
     this.connector.logger?.log(`Code loaded, iframe initialized`);
 
     await iframe.readyPromise;

--- a/src/SandboxedWallet/iframe.ts
+++ b/src/SandboxedWallet/iframe.ts
@@ -18,7 +18,7 @@ class IframeExecutor {
     this.readyPromiseResolve = resolve;
   });
 
-  constructor(readonly executor: SandboxExecutor, code: string, onMessage: (iframe: IframeExecutor, event: MessageEvent) => void) {
+  constructor(readonly executor: SandboxExecutor, code: string, onMessage: (iframe: IframeExecutor, event: MessageEvent) => void, cspNonce?: string) {
     this.origin = uuid4();
     this.handler = (event: MessageEvent<any>) => {
       if (event.data.origin !== this.origin) return;
@@ -37,7 +37,7 @@ class IframeExecutor {
     this.iframe.allow = iframeAllowedPermissions.join(" ");
     this.iframe.setAttribute("sandbox", "allow-scripts");
 
-    getIframeCode({ id: this.origin, executor: this.executor, code }).then((code) => {
+    getIframeCode({ id: this.origin, executor: this.executor, code, cspNonce }).then((code) => {
       this.executor.connector.logger?.log(`Iframe code injected`);
       this.iframe.srcdoc = code;
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { ParentFrameWallet } from "./ParentFrameWallet";
 export { SandboxWallet } from "./SandboxedWallet";
 export { InjectedWallet } from "./InjectedWallet";
 export { NearConnector } from "./NearConnector";
+export type { NearConnectorOptions } from "./NearConnector";
 
 export { nearActionsToConnectorActions } from "./actions";
 export type { ConnectorAction } from "./actions/types";


### PR DESCRIPTION
## Problem

`near-connect` creates sandboxed iframes using `<iframe srcdoc="...">`. Per the HTML spec, `srcdoc` iframes **inherit the parent page's Content Security Policy**. When the parent uses nonce-based CSP (e.g. `script-src 'nonce-abc123'`), the two inline `<script>` tags inside the `srcdoc` are blocked — they have no `nonce` attribute, so the browser refuses to execute them.

The result: on sites with strict nonce-based CSP, the wallet iframe loads but is completely inert. The runtime bridge (`window.selector`) never initializes, the message handler never runs, and the wallet module code never executes. No error is shown to the user — the popup just sits there silently.

## Fix

Add a `cspNonce` option to `NearConnector` that propagates the parent's nonce into both `<script>` tags inside the `srcdoc` iframe:

```ts
const connector = new NearConnector({
  cspNonce: document.querySelector('script[nonce]')?.getAttribute('nonce') ?? undefined,
});
```

When set, both scripts get `nonce="..."` added — the runtime shim (`window.selector`, `ProxyWindow`, message listener) and the wallet ES module code. When unset (default), behavior is unchanged.

The nonce is sanitized to base64 characters only (`[A-Za-z0-9+/=]`) before interpolation.

## Why nonce over alternatives

| Approach | CSP compliance | Security |
|----------|---------------|----------|
| **Nonce passthrough** (this PR) | Scripts execute with correct nonce | Wallet code still governed by parent's full CSP (`connect-src`, `frame-src`, etc.) |
| **`blob:` URL** | Avoids CSP entirely | Wallet code escapes all CSP restrictions — `fetch`/XHR unrestricted |
| **Hash-based CSP** | Would require updating hashes on every wallet code change | Impractical for dynamic content |
| **`'unsafe-inline'`** | Defeats the purpose of CSP | Not acceptable for security-conscious sites |

Nonce passthrough preserves the CSP inheritance that `srcdoc` provides — this is a security feature, not a bug. Wallet code remains constrained by the parent's `connect-src`, `img-src`, etc. A `blob:` URL would bypass all of that.

## Changes

- `src/NearConnector.ts` — `cspNonce` in `NearConnectorOptions` (now exported), class property, constructor
- `src/SandboxedWallet/executor.ts` — Passes `connector.cspNonce` to `IframeExecutor`
- `src/SandboxedWallet/iframe.ts` — Accepts `cspNonce`, forwards to `getIframeCode()`
- `src/SandboxedWallet/code.ts` — Sanitizes nonce, adds `nonce="..."` to both `<script>` tags
- `src/index.ts` — Exports `NearConnectorOptions` type
- `package.json` — Bumped to `0.11.4`
- `CHANGELOG.md`, `README.md`, `llms.txt` — Documented